### PR TITLE
Allow Skipping a SQS Queue if Tag is Present

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ All the configuration is currently setup with Environment Variables.  This conta
  - `MD_ECS_TASK_LAUNCH` (default: EC2) - The launch type for the task definition (can be `EC2` or `Fargate`)
  - `MD_ECS_TASK_CONTAINER_ENVIRONMENT` (optional) - A json object (example below) of environment variables you want to set when the task is started
  - `MD_ECS_TASK_CONTAINER_NAME` (required only if `MD_ECS_TASK_CONTAINER_ENVIRONMENT` is set) - The name of the container you want to override with different environment variables 
+ - `MD_QUEUE_TAG_TO_SKIP` (optional) - "Key" value of the tag attached to the SQS Queue, where if present, will not be monitored
 
 ## Environment Variable Example
 You can override the list of environment variables for a task when a queue triggers it to start.  This can be helpful if you have settings specific to the queue.

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -145,6 +145,18 @@ namespace MessageDelivery
                                 _runningECSTasks.Add(queueUrl, taskItem.Value);
                                 possibleRunningQueues.Remove(taskItem.Key);
                             }
+                            if(!string.IsNullOrEmpty(Settings.QueueTagToSkip))
+                            {
+                                var queueTags = await _sqsClient.ListQueueTagsAsync(new ListQueueTagsRequest() { QueueUrl = queueUrl }, monitorCancellationToken.Token);
+                                if(queueTags.HttpStatusCode == HttpStatusCode.OK)
+                                {
+                                    if(queueTags.Tags.ContainsKey(Settings.QueueTagToSkip))
+                                    {
+                                        Log.Information($"Queue ({queueUrl}) flagged to skip ({Settings.QueueTagToSkip})");
+                                        continue; // Don't monitor
+                                    }
+                                }
+                            }
                             MonitorQueue(queueUrl, monitorCancellationToken.Token);
                         }
                     }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -156,6 +156,10 @@ namespace MessageDelivery
                                         continue; // Don't monitor
                                     }
                                 }
+                                else
+                                {
+                                    Log.Error($"Unable to get check tags for queue ({queueUrl})");
+                                }
                             }
                             MonitorQueue(queueUrl, monitorCancellationToken.Token);
                         }

--- a/src/Settings.cs
+++ b/src/Settings.cs
@@ -29,6 +29,8 @@ namespace MessageDelivery
 
         public static int QueueMessageCountCheckIfActiveInMinutes { get; private set; } = 5;
         
+        public static string QueueTagToSkip { get; private set; } = string.Empty;
+
         public static string ECSClusterARN { get; private set; }
 
         public static string ECSTaskDefinitionARN { get; private set; }
@@ -59,6 +61,7 @@ namespace MessageDelivery
                 QueueMessageCountCheckIfBlankInSeconds = queueBlankMessageCheck;
             if(int.TryParse(Environment.GetEnvironmentVariable("MD_QUEUE_ACTIVE_MESSAGE_REFRESH"), out int queueActiveMessageRefresh))
                 QueueMessageCountCheckIfActiveInMinutes = queueActiveMessageRefresh;
+            QueueTagToSkip = Environment.GetEnvironmentVariable("MD_QUEUE_TAG_TO_SKIP");
             ECSClusterARN = Environment.GetEnvironmentVariable("MD_ECS_CLUSTER_ARN") ?? throw new ArgumentNullException("MD_ECS_CLUSTER_ARN is required");
             ECSTaskDefinitionARN = Environment.GetEnvironmentVariable("MD_ECS_TASK_ARN") ?? throw new ArgumentNullException("MD_ECS_TASK_ARN is required");;
             var launchType = Environment.GetEnvironmentVariable("MD_ECS_TASK_LAUNCH");


### PR DESCRIPTION
Is a tag is present (configured in `MD_QUEUE_TAG_TO_SKIP`), then the queue doesn’t need to be monitored