### PR TITLE
Possible error when checking tasks

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -142,7 +142,8 @@ namespace MessageDelivery
                             if(possibleRunningQueues.Any(p => $"MDS-{queueName}".StartsWith(p.Key)))
                             {
                                 var taskItem = possibleRunningQueues.FirstOrDefault(p => $"MDS-{queueName}".StartsWith(p.Key));
-                                _runningECSTasks.Add(queueUrl, taskItem.Value);
+                                if(!_runningECSTasks.TryAdd(queueUrl, taskItem.Value))
+                                    Log.Information($"We already know a task is running for MDS-{queueName}");
                                 possibleRunningQueues.Remove(taskItem.Key);
                             }
                             if(!string.IsNullOrEmpty(Settings.QueueTagToSkip))


### PR DESCRIPTION
When checking for running tasks, it might fail after the first time since the queue might still be running.  We will now try to add it to the list and log if it's already running silently.